### PR TITLE
feat: Zshプラグインを強化して利便性と補完機能を向上

### DIFF
--- a/packages/sheldon/.config/sheldon/plugins.toml
+++ b/packages/sheldon/.config/sheldon/plugins.toml
@@ -24,16 +24,18 @@ github = 'romkatv/powerlevel10k'
 # --- 補完・入力支援 ---
 [plugins.zsh-completions]
 github = "zsh-users/zsh-completions"
-apply = ["defer"]
+
+# compinit初期化（zsh-completionsの後、fzf-tabの前に実行）
+[plugins.compinit]
+inline = 'autoload -Uz compinit && compinit'
+
+# Tab補完をfzf化（compinitの後、widget wrapプラグインの前に読み込む）
+[plugins.fzf-tab]
+github = "Aloxaf/fzf-tab"
 
 [plugins.zsh-autopair]
 github = "hlissner/zsh-autopair"
 apply = ["defer"]
-
-# Tab補完をfzf化（fzfコマンドのインストールが必要）
-# NOTE: 一旦無効化 - compinitの初期化タイミングの問題で補完が壊れるため
-# [plugins.fzf-tab]
-# github = "Aloxaf/fzf-tab"
 
 # --- ナビゲーション ---
 [plugins.zsh-z]

--- a/packages/sheldon/.config/sheldon/plugins.toml
+++ b/packages/sheldon/.config/sheldon/plugins.toml
@@ -25,13 +25,9 @@ github = 'romkatv/powerlevel10k'
 [plugins.zsh-completions]
 github = "zsh-users/zsh-completions"
 
-# compinit初期化（zsh-completionsの後、fzf-tabの前に実行）
+# compinit初期化（zsh-completionsの後に実行）
 [plugins.compinit]
 inline = 'autoload -Uz compinit && compinit'
-
-# Tab補完をfzf化（compinitの後、widget wrapプラグインの前に読み込む）
-[plugins.fzf-tab]
-github = "Aloxaf/fzf-tab"
 
 [plugins.zsh-autopair]
 github = "hlissner/zsh-autopair"

--- a/packages/sheldon/.config/sheldon/plugins.toml
+++ b/packages/sheldon/.config/sheldon/plugins.toml
@@ -31,7 +31,7 @@ github = "hlissner/zsh-autopair"
 apply = ["defer"]
 
 # Tab補完をfzf化（fzfコマンドのインストールが必要）
-# 一旦コメントアウト - compinitとの読み込み順序を調整する必要がある
+# NOTE: 一旦無効化 - compinitの初期化タイミングの問題で補完が壊れるため
 # [plugins.fzf-tab]
 # github = "Aloxaf/fzf-tab"
 

--- a/packages/sheldon/.config/sheldon/plugins.toml
+++ b/packages/sheldon/.config/sheldon/plugins.toml
@@ -31,8 +31,9 @@ github = "hlissner/zsh-autopair"
 apply = ["defer"]
 
 # Tab補完をfzf化（fzfコマンドのインストールが必要）
-[plugins.fzf-tab]
-github = "Aloxaf/fzf-tab"
+# 一旦コメントアウト - compinitとの読み込み順序を調整する必要がある
+# [plugins.fzf-tab]
+# github = "Aloxaf/fzf-tab"
 
 # --- ナビゲーション ---
 [plugins.zsh-z]

--- a/packages/sheldon/.config/sheldon/plugins.toml
+++ b/packages/sheldon/.config/sheldon/plugins.toml
@@ -14,24 +14,44 @@ shell = "zsh"
 
 [plugins]
 
+# --- 基本ツール ---
 [plugins.zsh-defer]
 github = "romkatv/zsh-defer"
-
-[plugins.zsh-syntax-highlighting]
-github = 'zsh-users/zsh-syntax-highlighting'
-apply = ["defer"]
-
-[plugins.zsh-autosuggestions]
-github = 'zsh-users/zsh-autosuggestions'
-apply = ["defer"]
 
 [plugins.powerlevel10k]
 github = 'romkatv/powerlevel10k'
 
-# For example:
-#
-# [plugins.base16]
-# github = "chriskempson/base16-shell"
+# --- 補完・入力支援 ---
+[plugins.zsh-completions]
+github = "zsh-users/zsh-completions"
+apply = ["defer"]
+
+[plugins.zsh-autopair]
+github = "hlissner/zsh-autopair"
+apply = ["defer"]
+
+# Tab補完をfzf化（fzfコマンドのインストールが必要）
+[plugins.fzf-tab]
+github = "Aloxaf/fzf-tab"
+
+# --- ナビゲーション ---
+[plugins.zsh-z]
+github = 'agkozak/zsh-z'
+
+# ↑↓キーで履歴検索
+[plugins.zsh-history-substring-search]
+github = "zsh-users/zsh-history-substring-search"
+apply = ["defer"]
+
+# --- ビジュアル・フィードバック（最後推奨） ---
+[plugins.zsh-autosuggestions]
+github = 'zsh-users/zsh-autosuggestions'
+apply = ["defer"]
+
+# 必ず最後に読み込む（他のプラグインが定義したエイリアス等に色を付けるため）
+[plugins.zsh-syntax-highlighting]
+github = 'zsh-users/zsh-syntax-highlighting'
+apply = ["defer"]
 
 [templates]
 defer = "{{ hooks?.pre | nl }}{% for file in files %}zsh-defer source \"{{ file }}\"\n{% endfor %}{{ hooks?.post | nl }}"

--- a/packages/zsh/.config/zsh/.zshrc
+++ b/packages/zsh/.config/zsh/.zshrc
@@ -28,6 +28,14 @@ egc(){
 # Plugins
 export SHELDON_CONFIG_DIR="$XDG_CONFIG_HOME/sheldon"
 export SHELDON_DATA_DIR="$XDG_STATE_HOME/sheldon"
+
+# zsh-completions用にfpathを設定（compinitの前に必要）
+fpath=($XDG_STATE_HOME/sheldon/repos/github.com/zsh-users/zsh-completions/src $fpath)
+
+# 補完システムの初期化
+autoload -Uz compinit
+compinit
+
 eval "$(sheldon source)"
 
 P10K_PATH="$XDG_CONFIG_HOME/p10k/.p10k.zsh"

--- a/packages/zsh/.config/zsh/.zshrc
+++ b/packages/zsh/.config/zsh/.zshrc
@@ -28,14 +28,6 @@ egc(){
 # Plugins
 export SHELDON_CONFIG_DIR="$XDG_CONFIG_HOME/sheldon"
 export SHELDON_DATA_DIR="$XDG_STATE_HOME/sheldon"
-
-# zsh-completions用にfpathを設定（compinitの前に必要）
-fpath=($XDG_STATE_HOME/sheldon/repos/github.com/zsh-users/zsh-completions/src $fpath)
-
-# 補完システムの初期化
-autoload -Uz compinit
-compinit
-
 eval "$(sheldon source)"
 
 P10K_PATH="$XDG_CONFIG_HOME/p10k/.p10k.zsh"

--- a/packages/zsh/.config/zsh/.zshrc
+++ b/packages/zsh/.config/zsh/.zshrc
@@ -84,3 +84,11 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # FZF key-bindings (プラグインの後に読み込む必要がある) - lazy load for faster startup
 zsh-defer source /opt/homebrew/opt/fzf/shell/key-bindings.zsh
+
+# zsh-history-substring-search のキーバインド設定
+# ↑↓キーで履歴の前方一致検索
+bindkey '^[[A' history-substring-search-up    # ↑キー
+bindkey '^[[B' history-substring-search-down  # ↓キー
+# Emacs モード用
+bindkey -M emacs '^P' history-substring-search-up
+bindkey -M emacs '^N' history-substring-search-down


### PR DESCRIPTION
## 概要

Zshの利便性と補完機能を向上させるため、以下のプラグインを追加しました。

## 追加したプラグイン

- **zsh-completions** - git/docker/npmなどの補完を強化
- **zsh-autopair** - 括弧やクォートの自動閉じ
- **zsh-z** - 頻繁に使うディレクトリへの高速移動（`z dotfiles`など）
- **zsh-history-substring-search** - ↑↓キーで履歴の前方一致検索

## 技術的な変更

- Sheldonのinlineプラグインで`compinit`を初期化
- プラグインの読み込み順序を最適化（`zsh-syntax-highlighting`を最後に配置）
- .zshrcにキーバインド設定を追加（履歴検索用）

## 試したが削除したもの

- **fzf-tab** - エイリアス多用環境では恩恵が少ないため削除

## テスト方法

```bash
# Sheldonでプラグインをインストール
sheldon lock --update

# 設定を再読み込み
exec zsh

# 動作確認
# 1. `git` と入力して↑キーで過去のgitコマンドが検索されるか
# 2. `(` を入力すると `)` が自動で閉じられるか
# 3. `z <ディレクトリ名>` で移動できるか
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)