### PR TITLE
feat: WezTerm設定をGNU Stowで管理できるように追加

### DIFF
--- a/packages/wezterm/.config/wezterm/keybinds.lua
+++ b/packages/wezterm/.config/wezterm/keybinds.lua
@@ -1,0 +1,192 @@
+local wezterm = require("wezterm")
+local act = wezterm.action
+
+-- Show which key table is active in the status area
+wezterm.on("update-right-status", function(window, pane)
+  local name = window:active_key_table()
+  if name then
+    name = "TABLE: " .. name
+  end
+  window:set_right_status(name or "")
+end)
+
+return {
+  keys = {
+    {
+      -- workspaceの切り替え
+      key = "w",
+      mods = "LEADER",
+      action = act.ShowLauncherArgs({ flags = "WORKSPACES", title = "Select workspace" }),
+    },
+    {
+      --workspaceの名前変更
+      key = "$",
+      mods = "LEADER",
+      action = act.PromptInputLine({
+        description = "(wezterm) Set workspace title:",
+        action = wezterm.action_callback(function(win, pane, line)
+          if line then
+            wezterm.mux.rename_workspace(wezterm.mux.get_active_workspace(), line)
+          end
+        end),
+      }),
+    },
+    {
+      key = "W",
+      mods = "LEADER|SHIFT",
+      action = act.PromptInputLine({
+        description = "(wezterm) Create new workspace:",
+        action = wezterm.action_callback(function(window, pane, line)
+          if line then
+            window:perform_action(
+              act.SwitchToWorkspace({
+                name = line,
+              }),
+              pane
+            )
+          end
+        end),
+      }),
+    },
+    -- コマンドパレット表示
+    { key = "p", mods = "SUPER", action = act.ActivateCommandPalette },
+    -- Tab切り替え
+    { key = "{", mods = "SUPER|SHIFT", action = act.ActivateTabRelative(-1) },
+    { key = "}", mods = "SUPER|SHIFT", action = act.ActivateTabRelative(1) },
+    -- Tab新規作成
+    { key = "t", mods = "SUPER", action = act({ SpawnTab = "CurrentPaneDomain" }) },
+    -- Tabを閉じる
+    { key = "w", mods = "SUPER", action = act({ CloseCurrentTab = { confirm = true } }) },
+
+    -- 画面フルスクリーン切り替え
+    { key = "Enter", mods = "ALT", action = act.ToggleFullScreen },
+
+    -- コピーモード
+    -- { key = 'X', mods = 'LEADER', action = act.ActivateKeyTable{ name = 'copy_mode', one_shot =false }, },
+    { key = "[", mods = "LEADER", action = act.ActivateCopyMode },
+    -- コピー
+    { key = "c", mods = "SUPER", action = act.CopyTo("Clipboard") },
+    -- 貼り付け
+    { key = "v", mods = "SUPER", action = act.PasteFrom("Clipboard") },
+
+    -- Pane作成 leader + r or d
+    { key = "d", mods = "LEADER", action = act.SplitVertical({ domain = "CurrentPaneDomain" }) },
+    { key = "r", mods = "LEADER", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
+    -- Paneを閉じる leader + x
+    { key = "x", mods = "LEADER", action = act({ CloseCurrentPane = { confirm = true } }) },
+    -- Pane移動 leader + hlkj
+    { key = "h", mods = "LEADER", action = act.ActivatePaneDirection("Left") },
+    { key = "l", mods = "LEADER", action = act.ActivatePaneDirection("Right") },
+    { key = "k", mods = "LEADER", action = act.ActivatePaneDirection("Up") },
+    { key = "j", mods = "LEADER", action = act.ActivatePaneDirection("Down") },
+    -- Pane選択
+    { key = "[", mods = "CTRL|SHIFT", action = act.PaneSelect },
+    -- 選択中のPaneのみ表示
+    { key = "z", mods = "LEADER", action = act.TogglePaneZoomState },
+
+    -- フォントサイズ切替
+    { key = "+", mods = "CTRL", action = act.IncreaseFontSize },
+    { key = "-", mods = "CTRL", action = act.DecreaseFontSize },
+    -- フォントサイズのリセット
+    { key = "0", mods = "CTRL", action = act.ResetFontSize },
+
+    -- タブ切替 Cmd + 数字
+    { key = "1", mods = "SUPER", action = act.ActivateTab(0) },
+    { key = "2", mods = "SUPER", action = act.ActivateTab(1) },
+    { key = "3", mods = "SUPER", action = act.ActivateTab(2) },
+    { key = "4", mods = "SUPER", action = act.ActivateTab(3) },
+    { key = "5", mods = "SUPER", action = act.ActivateTab(4) },
+    { key = "6", mods = "SUPER", action = act.ActivateTab(5) },
+    { key = "7", mods = "SUPER", action = act.ActivateTab(6) },
+    { key = "8", mods = "SUPER", action = act.ActivateTab(7) },
+    { key = "9", mods = "SUPER", action = act.ActivateTab(-1) },
+
+    -- コマンドパレット
+    -- { key = "p", mods = "SHIFT|CTRL", action = act.ActivateCommandPalette },
+    -- 設定再読み込み
+    { key = "r", mods = "SHIFT|CTRL", action = act.ReloadConfiguration },
+    -- キーテーブル用
+    { key = "s", mods = "LEADER", action = act.ActivateKeyTable({ name = "resize_pane", one_shot = false }) },
+    {
+      key = "a",
+      mods = "LEADER",
+      action = act.ActivateKeyTable({ name = "activate_pane", timeout_milliseconds = 1000 }),
+    },
+  },
+  -- キーテーブル
+  -- https://wezfurlong.org/wezterm/config/key-tables.html
+  key_tables = {
+    -- Paneサイズ調整 leader + s
+    resize_pane = {
+      { key = "h", action = act.AdjustPaneSize({ "Left", 1 }) },
+      { key = "l", action = act.AdjustPaneSize({ "Right", 1 }) },
+      { key = "k", action = act.AdjustPaneSize({ "Up", 1 }) },
+      { key = "j", action = act.AdjustPaneSize({ "Down", 1 }) },
+
+      -- Cancel the mode by pressing escape
+      { key = "Enter", action = "PopKeyTable" },
+    },
+    activate_pane = {
+      { key = "h", action = act.ActivatePaneDirection("Left") },
+      { key = "l", action = act.ActivatePaneDirection("Right") },
+      { key = "k", action = act.ActivatePaneDirection("Up") },
+      { key = "j", action = act.ActivatePaneDirection("Down") },
+    },
+    -- copyモード leader + [
+    copy_mode = {
+      -- 移動
+      { key = "h", mods = "NONE", action = act.CopyMode("MoveLeft") },
+      { key = "j", mods = "NONE", action = act.CopyMode("MoveDown") },
+      { key = "k", mods = "NONE", action = act.CopyMode("MoveUp") },
+      { key = "l", mods = "NONE", action = act.CopyMode("MoveRight") },
+      -- 最初と最後に移動
+      { key = "^", mods = "NONE", action = act.CopyMode("MoveToStartOfLineContent") },
+      { key = "$", mods = "NONE", action = act.CopyMode("MoveToEndOfLineContent") },
+      -- 左端に移動
+      { key = "0", mods = "NONE", action = act.CopyMode("MoveToStartOfLine") },
+      { key = "o", mods = "NONE", action = act.CopyMode("MoveToSelectionOtherEnd") },
+      { key = "O", mods = "NONE", action = act.CopyMode("MoveToSelectionOtherEndHoriz") },
+      --
+      { key = ";", mods = "NONE", action = act.CopyMode("JumpAgain") },
+      -- 単語ごと移動
+      { key = "w", mods = "NONE", action = act.CopyMode("MoveForwardWord") },
+      { key = "b", mods = "NONE", action = act.CopyMode("MoveBackwardWord") },
+      { key = "e", mods = "NONE", action = act.CopyMode("MoveForwardWordEnd") },
+      -- ジャンプ機能 t f
+      { key = "t", mods = "NONE", action = act.CopyMode({ JumpForward = { prev_char = true } }) },
+      { key = "f", mods = "NONE", action = act.CopyMode({ JumpForward = { prev_char = false } }) },
+      { key = "T", mods = "NONE", action = act.CopyMode({ JumpBackward = { prev_char = true } }) },
+      { key = "F", mods = "NONE", action = act.CopyMode({ JumpBackward = { prev_char = false } }) },
+      -- 一番下へ
+      { key = "G", mods = "NONE", action = act.CopyMode("MoveToScrollbackBottom") },
+      -- 一番上へ
+      { key = "g", mods = "NONE", action = act.CopyMode("MoveToScrollbackTop") },
+      -- viweport
+      { key = "H", mods = "NONE", action = act.CopyMode("MoveToViewportTop") },
+      { key = "L", mods = "NONE", action = act.CopyMode("MoveToViewportBottom") },
+      { key = "M", mods = "NONE", action = act.CopyMode("MoveToViewportMiddle") },
+      -- スクロール
+      { key = "b", mods = "CTRL", action = act.CopyMode("PageUp") },
+      { key = "f", mods = "CTRL", action = act.CopyMode("PageDown") },
+      { key = "d", mods = "CTRL", action = act.CopyMode({ MoveByPage = 0.5 }) },
+      { key = "u", mods = "CTRL", action = act.CopyMode({ MoveByPage = -0.5 }) },
+      -- 範囲選択モード
+      { key = "v", mods = "NONE", action = act.CopyMode({ SetSelectionMode = "Cell" }) },
+      { key = "v", mods = "CTRL", action = act.CopyMode({ SetSelectionMode = "Block" }) },
+      { key = "V", mods = "NONE", action = act.CopyMode({ SetSelectionMode = "Line" }) },
+      -- コピー
+      { key = "y", mods = "NONE", action = act.CopyTo("Clipboard") },
+
+      -- コピーモードを終了
+      {
+        key = "Enter",
+        mods = "NONE",
+        action = act.Multiple({ { CopyTo = "ClipboardAndPrimarySelection" }, { CopyMode = "Close" } }),
+      },
+      { key = "Escape", mods = "NONE", action = act.CopyMode("Close") },
+      { key = "c", mods = "CTRL", action = act.CopyMode("Close") },
+      { key = "q", mods = "NONE", action = act.CopyMode("Close") },
+    },
+  },
+}
+

--- a/packages/wezterm/.config/wezterm/wezterm.lua
+++ b/packages/wezterm/.config/wezterm/wezterm.lua
@@ -1,0 +1,84 @@
+local wezterm = require("wezterm")
+local config = wezterm.config_builder()
+
+config.automatically_reload_config = true
+config.font_size = 13.0
+config.use_ime = true
+config.window_background_opacity = 0.75
+config.macos_window_background_blur = 20
+
+----------------------------------------------------
+-- Tab
+----------------------------------------------------
+-- タイトルバーを非表示
+config.window_decorations = "RESIZE"
+-- タブバーの表示
+config.show_tabs_in_tab_bar = true
+-- タブが一つの時は非表示
+config.hide_tab_bar_if_only_one_tab = true
+-- falseにするとタブバーの透過が効かなくなる
+-- config.use_fancy_tab_bar = false
+
+-- タブバーの透過
+config.window_frame = {
+  inactive_titlebar_bg = "none",
+  active_titlebar_bg = "none",
+}
+
+-- タブバーを背景色に合わせる
+config.window_background_gradient = {
+  colors = { "#000000" },
+}
+
+-- タブの追加ボタンを非表示
+config.show_new_tab_button_in_tab_bar = false
+-- nightlyのみ使用可能
+-- タブの閉じるボタンを非表示
+-- config.show_close_tab_button_in_tabs = false
+
+-- タブ同士の境界線を非表示
+config.colors = {
+  tab_bar = {
+    inactive_tab_edge = "none",
+  },
+}
+
+-- タブの形をカスタマイズ
+-- タブの左側の装飾
+local SOLID_LEFT_ARROW = wezterm.nerdfonts.ple_lower_right_triangle
+-- タブの右側の装飾
+local SOLID_RIGHT_ARROW = wezterm.nerdfonts.ple_upper_left_triangle
+
+wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
+  local background = "#5c6d74"
+  local foreground = "#FFFFFF"
+  local edge_background = "none"
+  if tab.is_active then
+    background = "#ae8b2d"
+    foreground = "#FFFFFF"
+  end
+  local edge_foreground = background
+  local title = "   " .. wezterm.truncate_right(tab.active_pane.title, max_width - 1) .. "   "
+  return {
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = SOLID_LEFT_ARROW },
+    { Background = { Color = background } },
+    { Foreground = { Color = foreground } },
+    { Text = title },
+    { Background = { Color = edge_background } },
+    { Foreground = { Color = edge_foreground } },
+    { Text = SOLID_RIGHT_ARROW },
+  }
+end)
+
+----------------------------------------------------
+-- keybinds
+----------------------------------------------------
+config.disable_default_key_bindings = true
+config.keys = require("keybinds").keys
+config.key_tables = require("keybinds").key_tables
+config.leader = { key = "q", mods = "CTRL", timeout_milliseconds = 2000 }
+
+return config
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -27,6 +27,7 @@ PACKAGES=(
     "karabiner"
     "p10k"
     "sheldon"
+    "wezterm"
 )
 
 echo "Stowing packages..."


### PR DESCRIPTION
## Summary
- `packages/wezterm/` パッケージを追加し、WezTermターミナルエミュレータの設定をGNU Stowで管理できるようにしました
- セットアップスクリプト（`scripts/setup.sh`）にweztermパッケージを追加しました

## 変更内容
- **新規追加**: `packages/wezterm/.config/wezterm/wezterm.lua` - メイン設定ファイル（タブバー、透明度、テーマなど）
- **新規追加**: `packages/wezterm/.config/wezterm/keybinds.lua` - キーバインド設定（workspace、pane、copy modeなど）
- **更新**: `scripts/setup.sh` - PACKAGESリストにweztermを追加

## Test plan
- [ ] `bash scripts/setup.sh` を実行して、weztermパッケージが正しくStowされることを確認
- [ ] `~/.config/wezterm` が `packages/wezterm/.config/wezterm` へのシンボリックリンクになっていることを確認
- [ ] WeZTermを起動して、設定が正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)